### PR TITLE
Update Externals_CAM.cfg

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -14,9 +14,9 @@ required = True
 
 [cosp2]
 local_path = src/physics/cosp2/src
-protocol = svn
-repo_url = https://github.com/CFMIP/COSPv2.0/tags/
-tag = v2.1.4cesm/src
+protocol = git
+repo_url = https://github.com/CFMIP/COSPv2.0
+tag = v2.1.4cesm
 required = True
 
 [clubb]


### PR DESCRIPTION
The repo_url is github , but the protocal is svn, which leads to unsuccessful download.